### PR TITLE
fallocate: rework incompatible options

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -313,9 +313,8 @@ int main(int argc, char **argv)
 	};
 
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
-		{ 'c', 'd', 'p', 'z' },
-		{ 'c', 'n' },
 		{ 'c', 'd', 'i', 'p', 'x', 'z'},
+		{ 'c', 'i', 'n', 'x' },
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;


### PR DESCRIPTION
Follow up to d95f9a6, addressing ordering requirements, natural incompatibilities between various options, and limitations of posix_fallocate.

@karelzak and @zeha This is my following up on the discussion in #3410 .  If I understand the note in `include/optutils.h` correctly, one whole row in that table should be redundant now (and I've removed it).  Hopefully these two lines are easier to reason about compared to what was here before.